### PR TITLE
Force collection view to update view

### DIFF
--- a/SimplePhotoViewer/ViewController/ViewController.swift
+++ b/SimplePhotoViewer/ViewController/ViewController.swift
@@ -138,6 +138,8 @@ extension ViewController: ZoomAnimatorDelegate {
     
     func referenceImageViewFrameInTransitioningView(for zoomAnimator: ZoomAnimator) -> CGRect? {
         
+        self.collectionView.layoutIfNeeded()
+        
         let cell = self.collectionView.cellForItem(at: self.selectedIndexPath) as! PhotoCollectionViewCell
         
         let cellFrame = self.collectionView.convert(cell.frame, to: self.view)


### PR DESCRIPTION
Force collection view to update view to prevent access null cell when doing a pan gesture in detail view (to access the cell of the same photo in collection view)