### PR TITLE
Fixed dismiss animation after rotation

### DIFF
--- a/FluidPhoto.xcodeproj/project.pbxproj
+++ b/FluidPhoto.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 				TargetAttributes = {
 					247378811E0D6302000F7F2A = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = A9WB53K8XM;
 						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
@@ -326,8 +325,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = A9WB53K8XM;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FluidPhoto/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.masamichi.FluidPhoto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -340,8 +340,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = A9WB53K8XM;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FluidPhoto/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.masamichi.FluidPhoto;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FluidPhoto/Base.lproj/Main.storyboard
+++ b/FluidPhoto/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Photos-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SimplePhotoViewer" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="FluidPhoto" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -21,8 +21,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="P1m-wF-aMS">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="P1m-wF-aMS">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Elt-KY-Fqz">
                                     <size key="itemSize" width="100" height="100"/>
@@ -31,7 +32,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PhotoCollectionViewCell" id="eSZ-mW-hZB" customClass="PhotoCollectionViewCell" customModule="SimplePhotoViewer" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PhotoCollectionViewCell" id="eSZ-mW-hZB" customClass="PhotoCollectionViewCell" customModule="FluidPhoto" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -61,12 +62,6 @@
                             </collectionView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="trailing" secondItem="P1m-wF-aMS" secondAttribute="trailing" id="6Gn-R8-cEp"/>
-                            <constraint firstItem="P1m-wF-aMS" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="rxk-Vq-o4k"/>
-                            <constraint firstItem="P1m-wF-aMS" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="yP5-Dg-YZv"/>
-                            <constraint firstAttribute="bottom" secondItem="P1m-wF-aMS" secondAttribute="bottom" id="zcg-fF-P9e"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Photos" id="0Aa-Nu-hDi"/>
                     <connections>
@@ -81,7 +76,7 @@
         <!--Zoom-->
         <scene sceneID="AFh-kq-a6v">
             <objects>
-                <viewController automaticallyAdjustsScrollViewInsets="NO" id="la0-MI-Tyg" customClass="PhotoPageContainerViewController" customModule="SimplePhotoViewer" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="la0-MI-Tyg" customClass="PhotoPageContainerViewController" customModule="FluidPhoto" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="SPd-xV-Jxj"/>
                         <viewControllerLayoutGuide type="bottom" id="9ae-1m-yvx"/>
@@ -123,7 +118,7 @@
         <!--Photo Zoom View Controller-->
         <scene sceneID="ph8-tL-GV2">
             <objects>
-                <viewController storyboardIdentifier="PhotoZoomViewController" automaticallyAdjustsScrollViewInsets="NO" id="yum-7x-ErO" customClass="PhotoZoomViewController" customModule="SimplePhotoViewer" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PhotoZoomViewController" automaticallyAdjustsScrollViewInsets="NO" id="yum-7x-ErO" customClass="PhotoZoomViewController" customModule="FluidPhoto" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="JaL-qF-Ng7"/>
                         <viewControllerLayoutGuide type="bottom" id="2Fo-1Z-Vky"/>

--- a/FluidPhoto/ViewController/PhotoZoomViewController.swift
+++ b/FluidPhoto/ViewController/PhotoZoomViewController.swift
@@ -39,18 +39,48 @@ class PhotoZoomViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.scrollView.delegate = self
-        self.scrollView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 11, *) {
+            self.scrollView.contentInsetAdjustmentBehavior = .never
+        }
         self.imageView.image = self.image
         self.imageView.frame = CGRect(x: self.imageView.frame.origin.x,
                                       y: self.imageView.frame.origin.y,
                                       width: self.image.size.width,
                                       height: self.image.size.height)
         self.view.addGestureRecognizer(self.doubleTapGestureRecognizer)
+        
+        //Update the constraints to prevent the constraints from
+        //being calculated incorrectly on certain iOS devices
+        self.updateConstraintsForSize(self.view.frame.size)
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateZoomScaleForSize(view.bounds.size)
+    }
+    
+    override func viewSafeAreaInsetsDidChange() {
+        
+        //When this view's safeAreaInsets change, propagate this information
+        //to the previous ViewController so the collectionView contentInsets
+        //can be updated accordingly. This is necessary in order to properly
+        //calculate the frame position for the dismiss (swipe down) animation
+
+        if #available(iOS 11, *) {
+            
+            //Get the parent view controller (ViewController) from the navigation controller
+            guard let parentVC = self.navigationController?.viewControllers.first as? ViewController else {
+                return
+            }
+            
+            //Update the ViewController's left and right local safeAreaInset variables
+            //with the safeAreaInsets for this current view. These will be used to
+            //update the contentInsets of the collectionView inside ViewController
+            parentVC.currentLeftSafeAreaInset = self.view.safeAreaInsets.left
+            parentVC.currentRightSafeAreaInset = self.view.safeAreaInsets.right
+            
+        }
+        
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/FluidPhoto/ViewController/ViewController.swift
+++ b/FluidPhoto/ViewController/ViewController.swift
@@ -16,8 +16,19 @@ class ViewController: UIViewController {
     
     var selectedIndexPath: IndexPath!
     
+    //These variables are used to hold any updates to the safeAreaInsets
+    //that might not have been propagated to this ViewController. This is required
+    //for supporting devices running on >= iOS 11. These will be set manually from
+    //PhotoZoomViewController.swift to ensure any changes to the safeAreaInsets
+    //after the device rotates are pushed to this ViewController. This is required
+    //to ensure the collectionView.convert() function calculates the proper
+    //frame result inside referenceImageViewFrameInTransitioningView()
+    var currentLeftSafeAreaInset  : CGFloat = 0.0
+    var currentRightSafeAreaInset : CGFloat = 0.0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         self.photos = [
             #imageLiteral(resourceName: "1"),
             #imageLiteral(resourceName: "2"),
@@ -56,12 +67,106 @@ class ViewController: UIViewController {
             #imageLiteral(resourceName: "17"),
             #imageLiteral(resourceName: "18")
         ]
+        
+        //Manually set the collectionView frame to the size of the view bounds
+        //(this is required to support iOS 10 devices and earlier)
+        self.collectionView.frame = self.view.bounds
+        
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
         self.navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
+    override func viewSafeAreaInsetsDidChange() {
+    
+        //if the application launches in landscape mode, the safeAreaInsets
+        //need to be updated from 0.0 if the device is an iPhone X model. At
+        //application launch this function is called before viewWillLayoutSubviews()
+        if #available(iOS 11, *) {
+            
+            self.currentLeftSafeAreaInset = self.view.safeAreaInsets.left
+            self.currentRightSafeAreaInset = self.view.safeAreaInsets.right
+        }
+        
+    }
+    
+    override func viewWillLayoutSubviews() {
+        
+        //Only perform these changes for devices running iOS 11 and later. This is called
+        //inside viewWillLayoutSubviews() instead of viewWillTransition() because when the
+        //device rotates, the navBarHeight and statusBarHeight will be calculated inside
+        //viewWillTransition() using the current orientation, and not the orientation
+        //that the device will be at the end of the transition.
+        
+        //By the time that viewWillLayoutSubviews() is called, the views frames have been
+        //properly updated for the new orientation, so the navBar and statusBar height values
+        //can be calculated and applied directly as per the code below
+        
+        if #available(iOS 11, *) {
+            
+            self.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: self.view.bounds.size)
+            self.collectionView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: self.view.bounds.size)
+            
+            self.collectionView.contentInsetAdjustmentBehavior = .never
+            let statusBarHeight : CGFloat = UIApplication.shared.statusBarFrame.height
+            let navBarHeight : CGFloat = navigationController?.navigationBar.frame.height ?? 0
+            self.edgesForExtendedLayout = .all
+            let tabBarHeight = self.tabBarController?.tabBar.frame.height ?? 0
+            
+            if UIDevice.current.orientation.isLandscape {
+                self.collectionView.contentInset = UIEdgeInsets(top: (navBarHeight) + statusBarHeight, left: self.currentLeftSafeAreaInset, bottom: tabBarHeight, right: self.currentRightSafeAreaInset)
+            }
+            else {
+                self.collectionView.contentInset = UIEdgeInsets(top: (navBarHeight) + statusBarHeight, left: 0.0, bottom: tabBarHeight, right: 0.0)
+            }
+        }
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        if #available(iOS 11, *) {
+            //Do nothing
+        }
+        else {
+            
+            //Support for devices running iOS 10 and below
+            
+            //Check to see if the view is currently visible, and if so,
+            //animate the frame transition to the new orientation
+            if self.viewIfLoaded?.window != nil {
+                
+                coordinator.animate(alongsideTransition: { _ in
+                    
+                    //This needs to be called inside viewWillTransition() instead of viewWillLayoutSubviews()
+                    //for devices running iOS 10.0 and earlier otherwise the frames for the view and the
+                    //collectionView will not be calculated properly.
+                    self.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
+                    self.collectionView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
+                    
+                }, completion: { _ in
+                    
+                    //Invalidate the collectionViewLayout
+                    self.collectionView.collectionViewLayout.invalidateLayout()
+                    
+                })
+                
+            }
+            //Otherwise, do not animate the transition
+            else {
+                
+                self.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
+                self.collectionView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
+    
+                //Invalidate the collectionViewLayout
+                self.collectionView.collectionViewLayout.invalidateLayout()
+                
+            }
+        }
+        
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -104,10 +209,87 @@ extension ViewController: UICollectionViewDelegate, UICollectionViewDataSource {
         self.selectedIndexPath = indexPath
         self.performSegue(withIdentifier: "ShowPhotoPageView", sender: self)
     }
+    
+    //This function prevents the collectionView from accessing a deallocated cell. In the event
+    //that the cell for the selectedIndexPath is nil, a default UIImageView is returned in its place
+    func getImageViewFromCollectionViewCell(for selectedIndexPath: IndexPath) -> UIImageView {
+        
+        //Get the array of visible cells in the collectionView
+        let visibleCells = self.collectionView.indexPathsForVisibleItems
+        
+        //If the current indexPath is not visible in the collectionView,
+        //scroll the collectionView to the cell to prevent it from returning a nil value
+        if !visibleCells.contains(self.selectedIndexPath) {
+           
+            //Scroll the collectionView to the current selectedIndexPath which is offscreen
+            self.collectionView.scrollToItem(at: self.selectedIndexPath, at: .centeredVertically, animated: false)
+            
+            //Reload the items at the newly visible indexPaths
+            self.collectionView.reloadItems(at: self.collectionView.indexPathsForVisibleItems)
+            self.collectionView.layoutIfNeeded()
+            
+            //Guard against nil values
+            guard let guardedCell = (self.collectionView.cellForItem(at: self.selectedIndexPath) as? PhotoCollectionViewCell) else {
+                //Return a default UIImageView
+                return UIImageView(frame: CGRect(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY, width: 100.0, height: 100.0))
+            }
+            //The PhotoCollectionViewCell was found in the collectionView, return the image
+            return guardedCell.imageView
+        }
+        else {
+            
+            //Guard against nil return values
+            guard let guardedCell = self.collectionView.cellForItem(at: self.selectedIndexPath) as? PhotoCollectionViewCell else {
+                //Return a default UIImageView
+                return UIImageView(frame: CGRect(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY, width: 100.0, height: 100.0))
+            }
+            //The PhotoCollectionViewCell was found in the collectionView, return the image
+            return guardedCell.imageView
+        }
+        
+    }
+    
+    //This function prevents the collectionView from accessing a deallocated cell. In the
+    //event that the cell for the selectedIndexPath is nil, a default CGRect is returned in its place
+    func getFrameFromCollectionViewCell(for selectedIndexPath: IndexPath) -> CGRect {
+        
+        //Get the currently visible cells from the collectionView
+        let visibleCells = self.collectionView.indexPathsForVisibleItems
+        
+        //If the current indexPath is not visible in the collectionView,
+        //scroll the collectionView to the cell to prevent it from returning a nil value
+        if !visibleCells.contains(self.selectedIndexPath) {
+            
+            //Scroll the collectionView to the cell that is currently offscreen
+            self.collectionView.scrollToItem(at: self.selectedIndexPath, at: .centeredVertically, animated: false)
+            
+            //Reload the items at the newly visible indexPaths
+            self.collectionView.reloadItems(at: self.collectionView.indexPathsForVisibleItems)
+            self.collectionView.layoutIfNeeded()
+            
+            //Prevent the collectionView from returning a nil value
+            guard let guardedCell = (self.collectionView.cellForItem(at: self.selectedIndexPath) as? PhotoCollectionViewCell) else {
+                return CGRect(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY, width: 100.0, height: 100.0)
+            }
+            
+            return guardedCell.frame
+        }
+        //Otherwise the cell should be visible
+        else {
+            //Prevent the collectionView from returning a nil value
+            guard let guardedCell = (self.collectionView.cellForItem(at: self.selectedIndexPath) as? PhotoCollectionViewCell) else {
+                return CGRect(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY, width: 100.0, height: 100.0)
+            }
+            //The cell was found successfully
+            return guardedCell.frame
+        }
+    }
+    
 }
 
 
 extension ViewController: PhotoPageContainerViewControllerDelegate {
+ 
     func containerViewController(_ containerViewController: PhotoPageContainerViewController, indexDidUpdate currentIndex: Int) {
         self.selectedIndexPath = IndexPath(row: currentIndex, section: 0)
         self.collectionView.scrollToItem(at: self.selectedIndexPath, at: .centeredVertically, animated: false)
@@ -115,6 +297,7 @@ extension ViewController: PhotoPageContainerViewControllerDelegate {
 }
 
 extension ViewController: ZoomAnimatorDelegate {
+    
     func transitionWillStartWith(zoomAnimator: ZoomAnimator) {
         
     }
@@ -132,17 +315,22 @@ extension ViewController: ZoomAnimatorDelegate {
     }
     
     func referenceImageView(for zoomAnimator: ZoomAnimator) -> UIImageView? {
-        let cell = self.collectionView.cellForItem(at: self.selectedIndexPath) as! PhotoCollectionViewCell
-        return cell.imageView
+        
+        //Get a guarded reference to the cell's UIImageView
+        let referenceImageView = getImageViewFromCollectionViewCell(for: self.selectedIndexPath)
+        
+        return referenceImageView
     }
     
     func referenceImageViewFrameInTransitioningView(for zoomAnimator: ZoomAnimator) -> CGRect? {
         
+        self.view.layoutIfNeeded()
         self.collectionView.layoutIfNeeded()
         
-        let cell = self.collectionView.cellForItem(at: self.selectedIndexPath) as! PhotoCollectionViewCell
+        //Get a guarded reference to the cell's frame
+        let unconvertedFrame = getFrameFromCollectionViewCell(for: self.selectedIndexPath)
         
-        let cellFrame = self.collectionView.convert(cell.frame, to: self.view)
+        let cellFrame = self.collectionView.convert(unconvertedFrame, to: self.view)
         
         if cellFrame.minY < self.collectionView.contentInset.top {
             return CGRect(x: cellFrame.minX, y: self.collectionView.contentInset.top, width: cellFrame.width, height: cellFrame.height - (self.collectionView.contentInset.top - cellFrame.minY))
@@ -150,4 +338,5 @@ extension ViewController: ZoomAnimatorDelegate {
         
         return cellFrame
     }
+    
 }


### PR DESCRIPTION
Fixes #9 

This branch fixes the dismiss animation after the device is rotated. Additionally, this also adds support for iOS 10 devices (which never supported iPhone X and the safe area layout). Also worth noting is that the collectionView.contentInsets are properly updated for all iPhone X devices on rotation.

There are a few minor bug fixes included as well, such as calling updateConstraintsForSize() inside the viewDidLoad() of PhotoZoomViewController. This was necessary to ensure the constraints updated properly for specific devices (in particular, the iPhone SE was causing the image to snap to the top of the screen instead of being centered). Also, I've added guard functions around collectionView.cellForItemAt() to prevent cases where the app would crash trying to access a nil value (this would occasionally happen when you scroll through a lot of images in the PageViewController and rotate the device).

Cheers!